### PR TITLE
Type missing from defcustom pyenv-mode-mode-line-format

### DIFF
--- a/pyenv-mode.el
+++ b/pyenv-mode.el
@@ -37,6 +37,7 @@
     (when (pyenv-mode-version)
       (concat "Pyenv:" (pyenv-mode-version) " ")))
   "How `pyenv-mode' will indicate the current python version in the mode line."
+  :type '(string)
   :group 'pyenv)
 
 (defun pyenv-mode-version ()


### PR DESCRIPTION
Emacs 29.1 reports an error when loading the pyenv module. I believe this fix is correct but I'm no Elisp expert.